### PR TITLE
Adapt for OpenPose v1.7.0

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -432,9 +432,10 @@ void run() {
     sl::Mat img_buffer, depth_img_buffer, depth_buffer, depth_buffer2;
     op::Array<float> outputArray, outputArray2;
     cv::Mat inputImage, depthImage, inputImageRGBA, outputImage;
+    float netInputResolutionDynamicBehavior = 0.0f; // no mNetInputResolutionDynamicBehavior behavior
 
     // ---- OPENPOSE INIT (io data + renderer) ----
-    op::ScaleAndSizeExtractor scaleAndSizeExtractor(netInputSize, outputSize, FLAGS_scale_number, FLAGS_scale_gap);
+    op::ScaleAndSizeExtractor scaleAndSizeExtractor(netInputSize, netInputResolutionDynamicBehavior, outputSize, FLAGS_scale_number, FLAGS_scale_gap);
     op::CvMatToOpInput cvMatToOpInput;
     op::CvMatToOpOutput cvMatToOpOutput;
 


### PR DESCRIPTION
When OpenPose released v1.7.0, it came a change in op::scaleAndSizeExtractor which does not allow to compile ZED-OpenPose with that particular version. 
Although the patch in this PR it is not fully functional, it allows compilation by hard-coded disabled netInputResolutionDynamicBehavior.

Resolves: Compilation issues with OpenPose v1.7.0.